### PR TITLE
Fix admin management and enhance dashboard look

### DIFF
--- a/Backend/Client/Main.html
+++ b/Backend/Client/Main.html
@@ -20,7 +20,7 @@
 </head>
 
 <body x-data="dashboardApp()" x-init="setTimeout(() => loading = false, 800)"
-    class="bg-gray-100 font-family-karla flex">
+    class="font-family-karla flex">
 
     <script>
         // Expose Alpine component methods globally for template includes or context leaks
@@ -181,19 +181,19 @@
                 <div x-show="$store.appStore.dashboardView" class="space-y-6">
                     <!-- Stats Cards -->
                     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-                        <div class="bg-white p-4 rounded shadow">
+                        <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Total Bookings</h3>
                             <p class="text-2xl font-bold text-gray-900" x-text="bookings.length"></p>
                         </div>
-                        <div class="bg-white p-4 rounded shadow">
+                        <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Today's Bookings</h3>
                             <p class="text-2xl font-bold text-blue-600" x-text="getTodayBookings().length"></p>
                         </div>
-                        <div class="bg-white p-4 rounded shadow">
+                        <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Total PAX</h3>
                             <p class="text-2xl font-bold text-green-600" x-text="getTotalPax()"></p>
                         </div>
-                        <div class="bg-white p-4 rounded shadow">
+                        <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Active Boats</h3>
                             <p class="text-2xl font-bold text-purple-600" x-text="boats.length"></p>
                         </div>
@@ -326,7 +326,7 @@
                 <div x-show="$store.appStore.messagesView" class="space-y-6">
                     <h1 class="text-2xl font-bold text-gray-800">Daily Messages</h1>
 
-                    <div class="bg-white rounded shadow p-6">
+                    <div class="card p-6">
                         <div class="flex flex-col md:flex-row gap-4 mb-4">
                             <div class="flex-1">
                                 <label class="block mb-1 font-semibold">Select Date</label>
@@ -366,7 +366,7 @@
                 <div x-show="isAdmin() && $store.appStore.adminView" class="space-y-6">
                     <h1 class="text-2xl font-bold text-gray-800">Admin Panel</h1>
 
-                    <div class="bg-white rounded shadow p-6">
+                    <div class="card p-6">
                         <div class="mb-6">
                             <h3 class="font-semibold mb-2">Users</h3>
                             <table id="usersTable" class="min-w-full bg-gray-50 rounded mb-4">
@@ -401,7 +401,7 @@
                                     </template>
                                 </tbody>
                             </table>
-                            <button @click="openAddUserModal()"
+                            <button type="button" @click.prevent="openAddUserModal"
                                 class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 flex items-center">
                                 <i class='bx bx-plus mr-2'></i> Add User
                             </button>
@@ -437,7 +437,7 @@
                                     </template>
                                 </tbody>
                             </table>
-                            <button @click="openAddBoatModal()"
+                            <button type="button" @click.prevent="openAddBoatModal"
                                 class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 flex items-center">
                                 <i class='bx bx-plus mr-2'></i> Add Boat
                             </button>

--- a/Backend/Client/Styles/Stylesheet.html
+++ b/Backend/Client/Styles/Stylesheet.html
@@ -3,7 +3,17 @@
 
 <style>
     .bg-sidebar {
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        background: linear-gradient(135deg, #1e3a8a 0%, #4c1d95 100%);
+    }
+
+    body {
+        background: linear-gradient(to bottom right, #f8fafc, #e0f2fe);
+    }
+
+    .card {
+        background: #fff;
+        border-radius: 0.5rem;
+        box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
     }
 
     .active-nav-link {

--- a/Backend/Code.js
+++ b/Backend/Code.js
@@ -103,10 +103,10 @@ function clearSheetCache(sheetName) {
   CacheService.getScriptCache().remove('data_' + sheetName);
 }
 
-// Check if user has specific permission
+// Check whether a user is authorized for a specific permission, treating the Admin role case-insensitively
 function hasPermission(user, permission) {
   if (!user || !user.Role) return false;
-  if (user.Role === 'Admin') return true;
+  if (String(user.Role).toLowerCase() === 'admin') return true;
   const perms = (user.Permissions || '').split(',').map(p => p.trim().toLowerCase());
   return perms.includes('all') || perms.includes(permission.toLowerCase());
 }


### PR DESCRIPTION
## Summary
- Allow admins to bypass permission checks case-insensitively for user deletion
- Ensure Add User and Add Boat buttons open their respective modals
- Apply deeper gradient styling and card component for a more pronounced UI

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ac04a4df74832586a8f5c42c09d110