### PR TITLE
Refactor booking modal layout and fix admin removal

### DIFF
--- a/Backend/Client/Components/Modals/BookingModal.html
+++ b/Backend/Client/Components/Modals/BookingModal.html
@@ -3,7 +3,7 @@
     x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100"
     x-transition:leave-end="opacity-0"
     class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50" x-cloak>
-    <div class="bg-white rounded-lg shadow-lg w-full max-w-2xl p-6 relative max-h-screen overflow-y-auto">
+    <div class="bg-white rounded-lg shadow-lg w-full max-w-4xl p-6 relative max-h-screen overflow-y-auto">
         <button @click="showBookingModal = false" class="absolute top-2 right-2 text-gray-400 hover:text-gray-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -11,159 +11,141 @@
         </button>
         <h2 class="text-xl font-bold mb-4" x-text="bookingModalTitle"></h2>
         <form @submit.prevent="saveBooking">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <!-- Basic Information -->
-                <div class="md:col-span-2">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="space-y-4">
                     <h3 class="font-semibold text-gray-700 mb-2">Basic Information</h3>
-                </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Date</label>
-                    <input type="date" x-model="bookingForm.date" class="w-full border px-3 py-2 rounded" required>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Date</label>
+                        <input type="date" x-model="bookingForm.date" class="w-full border px-3 py-2 rounded" required>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Boat</label>
-                    <select x-model="bookingForm.boat" class="w-full border px-3 py-2 rounded" required>
-                        <option value="">Select boat</option>
-                        <option value="MAYA">MAYA</option>
-                        <option value="PEARL">PEARL</option>
-                        <option value="BELLA">BELLA</option>
-                        <option value="SUNSET">SUNSET</option>
-                    </select>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Boat</label>
+                        <select x-model="bookingForm.boat" class="w-full border px-3 py-2 rounded" required>
+                            <option value="">Select boat</option>
+                            <option value="MAYA">MAYA</option>
+                            <option value="PEARL">PEARL</option>
+                            <option value="BELLA">BELLA</option>
+                            <option value="SUNSET">SUNSET</option>
+                        </select>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Trip Type</label>
-                    <select x-model="bookingForm.tripType" class="w-full border px-3 py-2 rounded" required>
-                        <option value="">Select type</option>
-                        <option value="Private">Private</option>
-                        <option value="Shared">Shared</option>
-                        <option value="Sunset">Sunset</option>
-                        <option value="DayOff">Day Off</option>
-                    </select>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Trip Type</label>
+                        <select x-model="bookingForm.tripType" class="w-full border px-3 py-2 rounded" required>
+                            <option value="">Select type</option>
+                            <option value="Private">Private</option>
+                            <option value="Shared">Shared</option>
+                            <option value="Sunset">Sunset</option>
+                            <option value="DayOff">Day Off</option>
+                        </select>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Status</label>
-                    <select x-model="bookingForm.status" class="w-full border px-3 py-2 rounded" required>
-                        <option value="Confirmed">Confirmed</option>
-                        <option value="Pending">Pending</option>
-                        <option value="Cancelled">Cancelled</option>
-                    </select>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Status</label>
+                        <select x-model="bookingForm.status" class="w-full border px-3 py-2 rounded" required>
+                            <option value="Confirmed">Confirmed</option>
+                            <option value="Pending">Pending</option>
+                            <option value="Cancelled">Cancelled</option>
+                        </select>
+                    </div>
 
-                <!-- Client Information -->
-                <div class="md:col-span-2">
                     <h3 class="font-semibold text-gray-700 mb-2 mt-4">Client Information</h3>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Clients</label>
+                        <input type="text" x-model="bookingForm.clients" class="w-full border px-3 py-2 rounded" required>
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Phone</label>
+                        <input type="tel" x-model="bookingForm.phone" class="w-full border px-3 py-2 rounded">
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Adults</label>
+                        <input type="number" x-model="bookingForm.adults" class="w-full border px-3 py-2 rounded" min="0" required>
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Children</label>
+                        <input type="number" x-model="bookingForm.children" class="w-full border px-3 py-2 rounded" min="0">
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Total PAX</label>
+                        <input type="number" x-model="bookingForm.totalPax" class="w-full border px-3 py-2 rounded" min="1" required>
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Child Ages</label>
+                        <input type="text" x-model="bookingForm.childAges" class="w-full border px-3 py-2 rounded" placeholder="e.g., 8;11">
+                    </div>
                 </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Clients</label>
-                    <input type="text" x-model="bookingForm.clients" class="w-full border px-3 py-2 rounded" required>
-                </div>
+                <div class="space-y-4">
+                    <h3 class="font-semibold text-gray-700 mb-2">Payment Information</h3>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Phone</label>
-                    <input type="tel" x-model="bookingForm.phone" class="w-full border px-3 py-2 rounded">
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Payment Amount</label>
+                        <input type="text" x-model="bookingForm.payment" class="w-full border px-3 py-2 rounded" placeholder="e.g., 480$">
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Adults</label>
-                    <input type="number" x-model="bookingForm.adults" class="w-full border px-3 py-2 rounded" min="0"
-                        required>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Payment Status</label>
+                        <select x-model="bookingForm.paid" class="w-full border px-3 py-2 rounded">
+                            <option value="TBC">TBC</option>
+                            <option value="Paid">Paid</option>
+                            <option value="Not paying">Not paying</option>
+                        </select>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Children</label>
-                    <input type="number" x-model="bookingForm.children" class="w-full border px-3 py-2 rounded" min="0">
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Commission</label>
+                        <input type="text" x-model="bookingForm.commission" class="w-full border px-3 py-2 rounded" placeholder="e.g., 40€">
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Total PAX</label>
-                    <input type="number" x-model="bookingForm.totalPax" class="w-full border px-3 py-2 rounded" min="1"
-                        required>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Partner</label>
+                        <input type="text" x-model="bookingForm.partner" class="w-full border px-3 py-2 rounded" placeholder="e.g., Nerea">
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Child Ages</label>
-                    <input type="text" x-model="bookingForm.childAges" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., 8;11">
-                </div>
-
-                <!-- Payment Information -->
-                <div class="md:col-span-2">
-                    <h3 class="font-semibold text-gray-700 mb-2 mt-4">Payment Information</h3>
-                </div>
-
-                <div>
-                    <label class="block mb-1 font-semibold">Payment Amount</label>
-                    <input type="text" x-model="bookingForm.payment" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., 480$">
-                </div>
-
-                <div>
-                    <label class="block mb-1 font-semibold">Payment Status</label>
-                    <select x-model="bookingForm.paid" class="w-full border px-3 py-2 rounded">
-                        <option value="TBC">TBC</option>
-                        <option value="Paid">Paid</option>
-                        <option value="Not paying">Not paying</option>
-                    </select>
-                </div>
-
-                <div>
-                    <label class="block mb-1 font-semibold">Commission</label>
-                    <input type="text" x-model="bookingForm.commission" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., 40€">
-                </div>
-
-                <div>
-                    <label class="block mb-1 font-semibold">Partner</label>
-                    <input type="text" x-model="bookingForm.partner" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., Nerea">
-                </div>
-
-                <!-- Transfer Information -->
-                <div class="md:col-span-2">
                     <h3 class="font-semibold text-gray-700 mb-2 mt-4">Transfer Information</h3>
-                </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Driver</label>
-                    <select x-model="bookingForm.driver" class="w-full border px-3 py-2 rounded">
-                        <option value="">Select driver</option>
-                        <option value="James">James</option>
-                        <option value="Juma">Juma</option>
-                        <option value="Jumah">Jumah</option>
-                        <option value="Momo">Momo</option>
-                    </select>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Driver</label>
+                        <select x-model="bookingForm.driver" class="w-full border px-3 py-2 rounded">
+                            <option value="">Select driver</option>
+                            <option value="James">James</option>
+                            <option value="Juma">Juma</option>
+                            <option value="Jumah">Jumah</option>
+                            <option value="Momo">Momo</option>
+                        </select>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Hotel/Location</label>
-                    <input type="text" x-model="bookingForm.hotel" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., White Sand">
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Hotel/Location</label>
+                        <input type="text" x-model="bookingForm.hotel" class="w-full border px-3 py-2 rounded" placeholder="e.g., White Sand">
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Transfer</label>
-                    <select x-model="bookingForm.transfer" class="w-full border px-3 py-2 rounded">
-                        <option value="No">No</option>
-                        <option value="Yes">Yes</option>
-                    </select>
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Transfer</label>
+                        <select x-model="bookingForm.transfer" class="w-full border px-3 py-2 rounded">
+                            <option value="No">No</option>
+                            <option value="Yes">Yes</option>
+                        </select>
+                    </div>
 
-                <div>
-                    <label class="block mb-1 font-semibold">Transfer Time</label>
-                    <input type="text" x-model="bookingForm.transferTime" class="w-full border px-3 py-2 rounded"
-                        placeholder="e.g., 8:30">
-                </div>
+                    <div>
+                        <label class="block mb-1 font-semibold">Transfer Time</label>
+                        <input type="text" x-model="bookingForm.transferTime" class="w-full border px-3 py-2 rounded" placeholder="e.g., 8:30">
+                    </div>
 
-                <!-- Comments -->
-                <div class="md:col-span-2">
-                    <label class="block mb-1 font-semibold">Comments</label>
-                    <textarea x-model="bookingForm.comments" class="w-full border px-3 py-2 rounded" rows="3"
-                        placeholder="Special notes, dietary requirements, etc."></textarea>
+                    <div>
+                        <label class="block mb-1 font-semibold">Comments</label>
+                        <textarea x-model="bookingForm.comments" class="w-full border px-3 py-2 rounded" rows="3" placeholder="Special notes, dietary requirements, etc."></textarea>
+                    </div>
                 </div>
             </div>
 

--- a/Backend/Code.js
+++ b/Backend/Code.js
@@ -468,10 +468,11 @@ function updateUser(requestingUser, id, userData) {
   }
 }
 
-// Delete user (soft delete)
+// Delete user (soft delete - requires admin)
 function deleteUser(requestingUser, id) {
   try {
-    if (!requestingUser || requestingUser.Role.toLowerCase() !== 'admin') {
+    var role = (requestingUser && requestingUser.Role) ? String(requestingUser.Role).toLowerCase().trim() : '';
+    if (role !== 'admin') {
       return { success: false, error: 'Unauthorized - Admin access required' };
     }
     


### PR DESCRIPTION
## Summary
- Restructure booking modal into a two-column layout with wider rectangular design
- Harden `deleteUser` authorization check to allow admins to remove users reliably

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68ac22e38df08325935e8fa0444a1dd7