### PR TITLE
Remove dummy data borders and expand booking modal

### DIFF
--- a/Backend/Client/Components/Modals/BookingModal.html
+++ b/Backend/Client/Components/Modals/BookingModal.html
@@ -11,7 +11,7 @@
         </button>
         <h2 class="text-xl font-bold mb-4" x-text="bookingModalTitle"></h2>
         <form @submit.prevent="saveBooking">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div class="space-y-4">
                     <h3 class="font-semibold text-gray-700 mb-2">Basic Information</h3>
 
@@ -50,8 +50,10 @@
                             <option value="Cancelled">Cancelled</option>
                         </select>
                     </div>
+                </div>
 
-                    <h3 class="font-semibold text-gray-700 mb-2 mt-4">Client Information</h3>
+                <div class="space-y-4">
+                    <h3 class="font-semibold text-gray-700 mb-2">Client Information</h3>
 
                     <div>
                         <label class="block mb-1 font-semibold">Clients</label>

--- a/Generator/SpreadsheetGenerator.js
+++ b/Generator/SpreadsheetGenerator.js
@@ -465,6 +465,10 @@ function addSampleActivityLogs(ss, now) {
     }
 }
 
+/**
+ * Auto-formats all sheets without adding borders to sample data
+ * @param {SpreadsheetApp} ss The spreadsheet instance
+ */
 function formatAllSheets(ss) {
     const sheets = ss.getSheets();
 
@@ -473,19 +477,12 @@ function formatAllSheets(ss) {
             const lastColumn = sheet.getLastColumn();
             const lastRow = sheet.getLastRow();
 
-            // Only format if there's data
             if (lastRow > 0 && lastColumn > 0) {
-                // Auto-resize columns (only if there are columns)
                 if (lastColumn > 0) {
                     sheet.autoResizeColumns(1, lastColumn);
                 }
 
-                // Add borders to data (only if there are multiple rows)
                 if (lastRow > 1) {
-                    const dataRange = sheet.getRange(1, 1, lastRow, lastColumn);
-                    dataRange.setBorder(true, true, true, true, true, true);
-
-                    // Set alternating row colors for better readability (skip header row)
                     for (let i = 2; i <= lastRow; i++) {
                         if (i % 2 === 0) {
                             sheet.getRange(i, 1, 1, lastColumn).setBackground('#f8f9fa');


### PR DESCRIPTION
## Summary
- Avoid borders when formatting generated sample data for cleaner sheets
- Adjust booking modal to a three-column layout for better information grouping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ac272857a8832581404b9254bcf4ce