### PR TITLE
feat: add boat color picker and expand booking modal

### DIFF
--- a/Backend/Client/Components/Modals/BoatModal.html
+++ b/Backend/Client/Components/Modals/BoatModal.html
@@ -10,8 +10,12 @@
                 <input type="text" x-model="boatForm.name" class="w-full border px-3 py-2 rounded" required>
             </div>
             <div class="mb-4">
-                <label class="block mb-1 font-semibold">Emoji/Color</label>
-                <input type="text" x-model="boatForm.color" class="w-full border px-3 py-2 rounded" placeholder="🛥️">
+                <label class="block mb-1 font-semibold">Color Label</label>
+                <input type="text" x-model="boatForm.colorLabel" class="w-full border px-3 py-2 rounded" placeholder="🛥️">
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1 font-semibold">Color Hex</label>
+                <input type="color" x-model="boatForm.colorHex" class="w-full border px-3 py-2 rounded">
             </div>
             <div class="mb-4">
                 <label class="block mb-1 font-semibold">Max Capacity</label>

--- a/Backend/Client/Components/Modals/BookingModal.html
+++ b/Backend/Client/Components/Modals/BookingModal.html
@@ -3,7 +3,7 @@
     x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100"
     x-transition:leave-end="opacity-0"
     class="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50" x-cloak>
-    <div class="bg-white rounded-lg shadow-lg w-full max-w-4xl p-6 relative max-h-screen overflow-y-auto">
+    <div class="bg-white rounded-lg shadow-lg w-full max-w-6xl p-6 relative max-h-screen overflow-y-auto">
         <button @click="showBookingModal = false" class="absolute top-2 right-2 text-gray-400 hover:text-gray-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -11,7 +11,7 @@
         </button>
         <h2 class="text-xl font-bold mb-4" x-text="bookingModalTitle"></h2>
         <form @submit.prevent="saveBooking">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div class="space-y-4">
                     <h3 class="font-semibold text-gray-700 mb-2">Basic Information</h3>
 
@@ -112,8 +112,10 @@
                         <label class="block mb-1 font-semibold">Partner</label>
                         <input type="text" x-model="bookingForm.partner" class="w-full border px-3 py-2 rounded" placeholder="e.g., Nerea">
                     </div>
+                </div>
 
-                    <h3 class="font-semibold text-gray-700 mb-2 mt-4">Transfer Information</h3>
+                <div class="space-y-4">
+                    <h3 class="font-semibold text-gray-700 mb-2">Transfer Information</h3>
 
                     <div>
                         <label class="block mb-1 font-semibold">Driver</label>

--- a/Backend/Client/Main.html
+++ b/Backend/Client/Main.html
@@ -519,7 +519,8 @@
                 editingUserId: null,
                 boatForm: {
                     name: '',
-                    color: '🛥️',
+                    colorLabel: '🛥️',
+                    colorHex: '#000000',
                     maxCapacity: 12,
                     managers: ''
                 },
@@ -629,7 +630,8 @@
                                     pageLength: 10,
                                     columns: [
                                         { data: 'Name', title: 'Name' },
-                                        { data: 'Color', title: 'Color' },
+                                        { data: 'ColorLabel', title: 'Label' },
+                                        { data: 'ColorHex', title: 'Color' },
                                         { data: 'MaxCapacity', title: 'Max Capacity' },
                                         { data: 'Managers', title: 'Managers' }
                                     ]
@@ -1060,7 +1062,8 @@
                     this.boatModalTitle = 'Add New Boat';
                     this.boatForm = {
                         name: '',
-                        color: '🛥️',
+                        colorLabel: '🛥️',
+                        colorHex: '#000000',
                         maxCapacity: 12,
                         managers: ''
                     };
@@ -1072,7 +1075,8 @@
                     this.boatModalTitle = 'Edit Boat';
                     this.boatForm = {
                         name: boat.Name,
-                        color: boat.Color,
+                        colorLabel: boat.ColorLabel,
+                        colorHex: boat.ColorHex,
                         maxCapacity: parseInt(boat.MaxCapacity) || 12,
                         managers: boat.Managers
                     };

--- a/Backend/Code.js
+++ b/Backend/Code.js
@@ -513,6 +513,7 @@ function deleteUser(requestingUser, id) {
 }
 
 // Add boat
+// Add a new boat record including color label and hex
 function addBoat(requestingUser, boatData) {
   try {
     if (!hasPermission(requestingUser, 'all')) {
@@ -528,9 +529,11 @@ function addBoat(requestingUser, boatData) {
     const newRow = [
       boatId,
       boatData.name,
-      boatData.color || '🛥️',
+      boatData.colorLabel || '🛥️',
+      boatData.colorHex || '#000000',
       boatData.maxCapacity || 12,
       boatData.managers || '',
+      boatData.tripTypesAllowed || '',
       'Yes',
       new Date().toISOString()
     ];
@@ -542,7 +545,7 @@ function addBoat(requestingUser, boatData) {
   }
 }
 
-// Update boat
+// Update boat details with color label and hex
 function updateBoat(requestingUser, id, boatData) {
   try {
     if (!hasPermission(requestingUser, 'all')) {
@@ -562,11 +565,13 @@ function updateBoat(requestingUser, id, boatData) {
         const updatedRow = [
           id,
           boatData.name,
-          boatData.color || '🛥️',
+          boatData.colorLabel || data[i][2],
+          boatData.colorHex || data[i][3],
           boatData.maxCapacity || 12,
           boatData.managers || '',
+          boatData.tripTypesAllowed || data[i][6],
           'Yes',
-          data[i][6]
+          data[i][8]
         ];
         sheet.getRange(i + 1, 1, 1, updatedRow.length).setValues([updatedRow]);
         clearSheetCache(BOATS_SHEET);


### PR DESCRIPTION
## Summary
- add label+hex color fields with color picker for boat management
- restructure booking modal into four columns and widen layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ac2f0724c483258449abf7f54ec339