### PR TITLE
Fix login handler and message date check

### DIFF
--- a/Backend/Client/Login.html
+++ b/Backend/Client/Login.html
@@ -7,7 +7,7 @@
             <p class="text-gray-600 mt-2">Sign in to your account</p>
         </div>
 
-        <form @submit.prevent="login()">
+        <form @submit.prevent="$root.login()" @keyup.enter="$root.login()">
             <div class="mb-4">
                 <label class="block mb-2 text-sm font-medium text-gray-700">Email</label>
                 <div class="relative">
@@ -24,7 +24,7 @@
                     <i class='bx bx-lock-alt absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400'></i>
                     <input type="password" name="password"
                         class="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                        placeholder="Enter your password" required>
+                        placeholder="Enter your password" required @keyup.enter="$root.login()">
                 </div>
             </div>
 

--- a/Backend/Code.js
+++ b/Backend/Code.js
@@ -654,13 +654,16 @@ function deleteBoat(requestingUser, id) {
   }
 }
 
-// Generate driver message with enhanced structure
+// Generate driver message for a given date, ensuring date normalization
 function generateDriverMessage(date) {
   try {
     const bookings = getBookings();
     if (!bookings.success) return { success: false, error: bookings.error };
 
-    const dayBookings = bookings.data.filter(booking => booking.Date === date && booking.Status !== 'Cancelled');
+    const dayBookings = bookings.data.filter(booking => {
+      const bookingDate = booking.Date instanceof Date ? booking.Date.toISOString().split('T')[0] : booking.Date;
+      return bookingDate === date && booking.Status !== 'Cancelled';
+    });
 
     if (dayBookings.length === 0) {
       return { success: true, message: 'No bookings found for this date.' };
@@ -683,13 +686,16 @@ function generateDriverMessage(date) {
   }
 }
 
-// Generate staff message with enhanced structure
+// Generate staff message for a given date, ensuring date normalization
 function generateStaffMessage(date) {
   try {
     const bookings = getBookings();
     if (!bookings.success) return { success: false, error: bookings.error };
 
-    const dayBookings = bookings.data.filter(booking => booking.Date === date && booking.Status !== 'Cancelled');
+    const dayBookings = bookings.data.filter(booking => {
+      const bookingDate = booking.Date instanceof Date ? booking.Date.toISOString().split('T')[0] : booking.Date;
+      return bookingDate === date && booking.Status !== 'Cancelled';
+    });
 
     if (dayBookings.length === 0) {
       return { success: true, message: 'No bookings found for this date.' };


### PR DESCRIPTION
## Summary
- Ensure login form calls the root login handler and supports enter key submission
- Normalize booking dates before generating driver or staff messages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ac55dc6c5c8325aec6dd15326e7e02