### PR TITLE
Add currency support and date-filtered boat summaries

### DIFF
--- a/Backend/Client/Components/Modals/BookingModal.html
+++ b/Backend/Client/Components/Modals/BookingModal.html
@@ -91,7 +91,16 @@
 
                     <div>
                         <label class="block mb-1 font-semibold">Payment Amount</label>
-                        <input type="text" x-model="bookingForm.payment" class="w-full border px-3 py-2 rounded" placeholder="e.g., 480$">
+                        <input type="text" x-model="bookingForm.payment" class="w-full border px-3 py-2 rounded" placeholder="e.g., 480">
+                    </div>
+
+                    <div>
+                        <label class="block mb-1 font-semibold">Currency</label>
+                        <select x-model="bookingForm.currency" class="w-full border px-3 py-2 rounded">
+                            <option value="USD">USD</option>
+                            <option value="EUR">EUR</option>
+                            <option value="TZS">TZS</option>
+                        </select>
                     </div>
 
                     <div>
@@ -105,7 +114,7 @@
 
                     <div>
                         <label class="block mb-1 font-semibold">Commission</label>
-                        <input type="text" x-model="bookingForm.commission" class="w-full border px-3 py-2 rounded" placeholder="e.g., 40€">
+                        <input type="text" x-model="bookingForm.commission" class="w-full border px-3 py-2 rounded" placeholder="e.g., 40">
                     </div>
 
                     <div>

--- a/Backend/Client/Main.html
+++ b/Backend/Client/Main.html
@@ -173,15 +173,23 @@
 
                 <!-- Dashboard View -->
                 <div x-show="$store.appStore.dashboardView" class="space-y-6">
-                    <!-- Stats Cards -->
-                    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-                        <div class="card p-4">
-                            <h3 class="text-sm font-medium text-gray-500">Total Bookings</h3>
-                            <p class="text-2xl font-bold text-gray-900" x-text="bookings.length"></p>
+                    <!-- Date Filters -->
+                    <div class="flex flex-col md:flex-row gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Start Date</label>
+                            <input type="date" x-model="filterStartDate" class="border px-2 py-1 rounded">
                         </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">End Date</label>
+                            <input type="date" x-model="filterEndDate" class="border px-2 py-1 rounded">
+                        </div>
+                    </div>
+
+                    <!-- Stats Cards -->
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div class="card p-4">
-                            <h3 class="text-sm font-medium text-gray-500">Today's Bookings</h3>
-                            <p class="text-2xl font-bold text-blue-600" x-text="getTodayBookings().length"></p>
+                            <h3 class="text-sm font-medium text-gray-500">Bookings</h3>
+                            <p class="text-2xl font-bold text-gray-900" x-text="filteredBookings().length"></p>
                         </div>
                         <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Total PAX</h3>
@@ -189,62 +197,34 @@
                         </div>
                         <div class="card p-4">
                             <h3 class="text-sm font-medium text-gray-500">Active Boats</h3>
-                            <p class="text-2xl font-bold text-purple-600" x-text="boats.length"></p>
+                            <p class="text-2xl font-bold text-purple-600" x-text="getActiveBoats()"></p>
                         </div>
                     </div>
 
-                    <!-- Bookings Table -->
+                    <!-- Boat Summary Table -->
                     <div class="bg-white rounded shadow overflow-hidden">
                         <div class="px-6 py-4 border-b">
-                            <h2 class="text-lg font-semibold text-gray-800">Recent Bookings</h2>
+                            <h2 class="text-lg font-semibold text-gray-800">Boat Summary</h2>
                         </div>
-                        <div class="p-6">
-                            <table id="bookingsTable" class="w-full">
+                        <div class="p-6 overflow-x-auto">
+                            <table id="summaryTable" class="w-full">
                                 <thead>
                                     <tr>
-                                        <th>Date</th>
-                                        <th>Trip Type</th>
                                         <th>Boat</th>
-                                        <th>Clients</th>
-                                        <th>PAX</th>
-                                        <th>Status</th>
-                                        <th>Actions</th>
+                                        <th>Trip Type</th>
+                                        <th>Adults</th>
+                                        <th>Children</th>
+                                        <th>Total PAX</th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <template x-for="booking in sortedBookings.filter(b => canViewBoat(b.Boat))"
-                                        :key="booking.BookingID">
+                                    <template x-for="item in getBoatSummary()" :key="item.Boat">
                                         <tr>
-                                            <td x-text="formatDate(booking.Date)"></td>
-                                            <td>
-                                                <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
-                                                    :class="getTripBadgeClass(booking.TripType)"
-                                                    x-text="booking.TripType"></span>
-                                            </td>
-                                            <td x-text="booking.Boat"></td>
-                                            <td x-text="booking.Clients"></td>
-                                            <td x-text="booking.TotalPAX"></td>
-                                            <td>
-                                                <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
-                                                    :class="getStatusBadgeClass(booking.Status)"
-                                                    x-text="booking.Status"></span>
-                                            </td>
-                                            <td>
-                                                <button
-                                                    @click="canEditBooking(booking) ? editBooking(booking) : showToast('No permission', 'error')"
-                                                    :disabled="!canEditBooking(booking)"
-                                                    class="text-blue-600 hover:text-blue-900 mr-2"
-                                                    :class="!canEditBooking(booking) ? 'opacity-50 cursor-not-allowed' : ''">
-                                                    <i class='bx bx-edit-alt'></i>
-                                                </button>
-                                                <button
-                                                    @click="canEditBooking(booking) ? deleteBooking(booking.BookingID) : showToast('No permission', 'error')"
-                                                    :disabled="!canEditBooking(booking)"
-                                                    class="text-red-600 hover:text-red-900"
-                                                    :class="!canEditBooking(booking) ? 'opacity-50 cursor-not-allowed' : ''">
-                                                    <i class='bx bx-trash'></i>
-                                                </button>
-                                            </td>
+                                            <td x-text="item.Boat"></td>
+                                            <td x-text="item.TripType"></td>
+                                            <td x-text="item.Adults"></td>
+                                            <td x-text="item.Children"></td>
+                                            <td x-text="item.TotalPAX"></td>
                                         </tr>
                                     </template>
                                 </tbody>
@@ -292,7 +272,7 @@
                                             <td x-text="booking.Boat"></td>
                                             <td x-text="booking.Clients"></td>
                                             <td x-text="booking.TotalPAX"></td>
-                                            <td x-text="booking.Payment"></td>
+                                            <td x-text="booking.Payment + ' ' + (booking.Currency || '')"></td>
                                             <td>
                                                 <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full"
                                                     :class="getStatusBadgeClass(booking.Status)"
@@ -489,6 +469,7 @@
                     childAges: '',
                     totalPax: 1,
                     payment: '',
+                    currency: 'USD',
                     paid: '',
                     commission: '',
                     partner: '',
@@ -499,6 +480,9 @@
                     comments: ''
                 },
                 editingBookingId: null,
+
+                filterStartDate: new Date().toISOString().split('T')[0],
+                filterEndDate: new Date().toISOString().split('T')[0],
 
                 // Messages
                 messageDate: new Date().toISOString().split('T')[0],
@@ -618,21 +602,6 @@
                 initializeDataTables() {
                     if ($.fn && $.fn.DataTable) {
                         const tables = {
-                            'bookingsTable': {
-                                config: {
-                                    responsive: true,
-                                    pageLength: 10,
-                                    order: [[0, 'desc']],
-                                    columns: [
-                                        { data: 'Date', title: 'Date' },
-                                        { data: 'Boat', title: 'Boat' },
-                                        { data: 'TripType', title: 'Trip Type' },
-                                        { data: 'Clients', title: 'Clients' },
-                                        { data: 'TotalPAX', title: 'PAX' },
-                                        { data: 'Status', title: 'Status' }
-                                    ]
-                                }
-                            },
                             'allBookingsTable': {
                                 config: {
                                     responsive: true,
@@ -710,6 +679,7 @@
                         childAges: '',
                         totalPax: 1,
                         payment: '',
+                        currency: 'USD',
                         paid: 'TBC',
                         commission: '',
                         partner: '',
@@ -737,6 +707,7 @@
                         childAges: booking.ChildAges || '',
                         totalPax: parseInt(booking.TotalPAX) || 1,
                         payment: booking.Payment || '',
+                        currency: booking.Currency || 'USD',
                         paid: booking.Paid || 'TBC',
                         commission: booking.Commission || '',
                         partner: booking.Partner || '',
@@ -882,24 +853,53 @@
                 },
 
                 // Computed properties
-                get sortedBookings() {
-                    return this.bookings.sort((a, b) => new Date(b.Date) - new Date(a.Date));
+                /** Returns bookings sorted by date descending */
+                sortedBookings() {
+                    return this.bookings.slice().sort((a, b) => new Date(b.Date) - new Date(a.Date));
                 },
 
-                getTodayBookings() {
-                    const today = new Date().toISOString().split('T')[0];
-                    return this.bookings.filter(booking => booking.Date === today);
+                /** Filters bookings by the selected start and end dates */
+                filteredBookings() {
+                    return this.bookings.filter(b => (!this.filterStartDate || b.Date >= this.filterStartDate) && (!this.filterEndDate || b.Date <= this.filterEndDate));
                 },
 
+                /** Calculates total passengers for filtered bookings */
                 getTotalPax() {
-                    return this.bookings.reduce((sum, booking) => sum + (parseInt(booking.TotalPAX) || 0), 0);
+                    return this.filteredBookings().reduce((sum, booking) => sum + (parseInt(booking.TotalPAX) || 0), 0);
+                },
+
+                /** Counts unique boats in filtered bookings */
+                getActiveBoats() {
+                    return new Set(this.filteredBookings().map(b => b.Boat)).size;
+                },
+
+                /** Aggregates booking details per boat for summary table */
+                getBoatSummary() {
+                    const map = {};
+                    this.filteredBookings().forEach(b => {
+                        if (!map[b.Boat]) {
+                            map[b.Boat] = { Boat: b.Boat, TripTypes: new Set(), Adults: 0, Children: 0, TotalPAX: 0 };
+                        }
+                        map[b.Boat].TripTypes.add(b.TripType);
+                        map[b.Boat].Adults += parseInt(b.Adults) || 0;
+                        map[b.Boat].Children += parseInt(b.Children) || 0;
+                        map[b.Boat].TotalPAX += parseInt(b.TotalPAX) || 0;
+                    });
+                    return Object.values(map).map(m => ({
+                        Boat: m.Boat,
+                        TripType: Array.from(m.TripTypes).join(', '),
+                        Adults: m.Adults,
+                        Children: m.Children,
+                        TotalPAX: m.TotalPAX
+                    }));
                 },
 
                 // Utility methods
+                /** Formats dates in day/month/year */
                 formatDate(dateString) {
                     if (!dateString) return '';
                     const date = new Date(dateString);
-                    return date.toLocaleDateString();
+                    return date.toLocaleDateString('fr-FR');
                 },
 
                 getTripColor(tripType) {

--- a/Backend/Code.js
+++ b/Backend/Code.js
@@ -191,6 +191,7 @@ function addBooking(user, bookingData) {
       bookingData.childAges || '',
       bookingData.totalPax,
       bookingData.payment || '',
+      bookingData.currency || '',
       bookingData.paid || 'TBC',
       bookingData.commission || '',
       bookingData.partner || '',
@@ -253,6 +254,7 @@ function updateBooking(user, id, bookingData) {
           bookingData.childAges || '',
           bookingData.totalPax,
           bookingData.payment || '',
+          bookingData.currency || '',
           bookingData.paid || 'TBC',
           bookingData.commission || '',
           bookingData.partner || '',
@@ -262,7 +264,7 @@ function updateBooking(user, id, bookingData) {
           bookingData.transferTime || '',
           bookingData.comments || '',
           'No',
-          data[i][22],
+          data[i][23],
           new Date().toISOString()
         ];
         sheet.getRange(i + 1, 1, 1, updatedRow.length).setValues([updatedRow]);

--- a/Generator/SpreadsheetGenerator.js
+++ b/Generator/SpreadsheetGenerator.js
@@ -61,7 +61,7 @@ function createBookingsSheet(ss) {
     const headers = [
         'BookingID', 'Date', 'Boat', 'TripType', 'TripColorHex', 'Status',
         'Clients', 'Phone', 'Adults', 'Children', 'ChildAges', 'TotalPAX',
-        'Payment', 'Paid', 'Commission', 'Partner', 'Driver', 'Hotel',
+        'Payment', 'Currency', 'Paid', 'Commission', 'Partner', 'Driver', 'Hotel',
         'Transfer', 'TransferTime', 'Comments', 'IsArchived', 'CreatedAt', 'UpdatedAt'
     ];
 
@@ -262,42 +262,42 @@ function addSampleBookings(ss, now) {
     const sampleBookings = [
         [
             'BOOK-20250805-0001', '2025-08-05', 'MAYA', 'Private', '#8B5CF6', 'Confirmed',
-            'Bella Vista', '+33 6 07 40 56 40', 7, 0, '', 7, '480$', 'TBC', '40€', 'Valentin', 'James', 'White Sand', 'Yes', '8:30',
+            'Bella Vista', '+33 6 07 40 56 40', 7, 0, '', 7, '480', 'USD', 'TBC', '40', 'Valentin', 'James', 'White Sand', 'Yes', '8:30',
             'Option for Sharlene until 31/07 morning 5 guests + 2 bodyguard', 'No', now, now
         ],
         [
             'BOOK-20250809-0001', '2025-08-09', 'PEARL', 'Shared', '#3B82F6', 'Confirmed',
-            'Aurélie', '+33 6 12 34 56 78', 2, 2, '10;11', 4, '170€', 'Paid', '20€', 'Nerea', 'Juma', 'Zan View', 'Yes', '8:30',
+            'Aurélie', '+33 6 12 34 56 78', 2, 2, '10;11', 4, '170', 'EUR', 'Paid', '20', 'Nerea', 'Juma', 'Zan View', 'Yes', '8:30',
             'Family with children', 'No', now, now
         ],
         [
             'BOOK-20250809-0002', '2025-08-09', 'PEARL', 'Shared', '#3B82F6', 'Confirmed',
-            'Amina et kaddour', '+33 6 98 76 54 32', 2, 0, '', 2, '150€', 'Paid', '15€', 'Nerea', 'Juma', 'Morroko Lounge', 'Yes', '9:15',
+            'Amina et kaddour', '+33 6 98 76 54 32', 2, 0, '', 2, '150', 'EUR', 'Paid', '15', 'Nerea', 'Juma', 'Morroko Lounge', 'Yes', '9:15',
             'Couple booking', 'No', now, now
         ],
         [
             'BOOK-20250810-0001', '2025-08-10', 'BELLA', 'Private', '#8B5CF6', 'Confirmed',
-            'Scott Busse', '+1 555 123 4567', 2, 0, '', 2, '320$', 'Paid', '32$', 'White Sand', 'Momo', 'Neptune Pwani', 'No', '',
+            'Scott Busse', '+1 555 123 4567', 2, 0, '', 2, '320', 'USD', 'Paid', '32', 'White Sand', 'Momo', 'Neptune Pwani', 'No', '',
             'Private sunset cruise', 'No', now, now
         ],
         [
             'BOOK-20250812-0001', '2025-08-12', 'MAYA', 'Sunset', '#F59E0B', 'Confirmed',
-            'German Family', '+49 30 123 4567', 4, 1, '8', 5, '400€', 'Paid', '40€', 'Be Zanzibar', 'Juma', 'Safaya Back', 'Yes', '17:30',
+            'German Family', '+49 30 123 4567', 4, 1, '8', 5, '400', 'EUR', 'Paid', '40', 'Be Zanzibar', 'Juma', 'Safaya Back', 'Yes', '17:30',
             'Sunset cruise with dinner', 'No', now, now
         ],
         [
             'BOOK-20250815-0001', '2025-08-15', 'PEARL', 'Shared', '#3B82F6', 'Confirmed',
-            'Manon and Maxime', '+33 6 11 22 33 44', 2, 0, '', 2, '0€', 'Not paying', '0€', 'Sonia - Moja Discovery', 'Jumah', 'Zan View', 'No', '',
+            'Manon and Maxime', '+33 6 11 22 33 44', 2, 0, '', 2, '0', 'EUR', 'Not paying', '0', 'Sonia - Moja Discovery', 'Jumah', 'Zan View', 'No', '',
             'Agency booking - commission only', 'No', now, now
         ],
         [
             'BOOK-20250818-0001', '2025-08-18', 'BELLA', 'Private', '#8B5CF6', 'Confirmed',
-            'Lara', '+33 6 99 88 77 66', 2, 0, '', 2, '0€', 'Not paying', '0€', 'Nerea', 'Jumah', 'Neptune Pwani', 'No', '',
+            'Lara', '+33 6 99 88 77 66', 2, 0, '', 2, '0', 'EUR', 'Not paying', '0', 'Nerea', 'Jumah', 'Neptune Pwani', 'No', '',
             'Nerea clients - no payment', 'No', now, now
         ],
         [
             'BOOK-20250820-0001', '2025-08-20', 'MAYA', 'DayOff', '#EF4444', 'Confirmed',
-            '', '', 0, 0, '', 0, '0€', '', '0€', '', '', '', 'No', '',
+            '', '', 0, 0, '', 0, '0', 'EUR', '', '0', '', '', '', 'No', '',
             'Boat maintenance day', 'No', now, now
         ]
     ];


### PR DESCRIPTION
## Summary
- add Currency column to bookings and generator sample data
- allow selecting payment currency in booking modal
- filter dashboard by date range and show per-boat summaries

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68acbc438bb08325ac5085544eacbae6